### PR TITLE
Fix openai client usage in automation script

### DIFF
--- a/automation/change_applier.py
+++ b/automation/change_applier.py
@@ -18,11 +18,11 @@ def generate_patch(issue_body, context):
 
 ### PATCH:
 """
-    response = openai.ChatCompletion.create(
+    response = openai.chat.completions.create(
         model="gpt-4",
         messages=[{"role": "user", "content": prompt}]
     )
-    return response["choices"][0]["message"]["content"]
+    return response.choices[0].message.content
 
 def apply_patch(patch_content, repo_dir="."):
     patch_file = os.path.join(repo_dir, "temp.patch")


### PR DESCRIPTION
## Summary
- update the change_applier automation script to use the new openai client API

## Testing
- `pytest -q`
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866113d5584832699d9993b40bb578e